### PR TITLE
Updating logback settings

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,15 +2,6 @@
 <configuration debug="true" scan="true">
 	<jmxConfigurator />
 
-	<appender name="DEFAULT" class="ch.qos.logback.core.FileAppender">
-		<file>jpo-aws-depositor.log</file>
-		<append>true</append>
-		<encoder>
-			<!-- <pattern>%-4relative [%thread] %-5level %logger{35} - %msg %n</pattern> -->
-			<pattern>%date{"yyyy-MM-dd HH:mm:ss.SSS", UTC} [%thread] %-5level %logger{0} - %msg %n</pattern>
-		</encoder>
-	</appender>
-
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
 			<pattern>%date{"yyyy-MM-dd HH:mm:ss.SSS", UTC} [%thread] %-5level %logger{0} - %msg %n</pattern>
@@ -19,7 +10,6 @@
 	
 	<logger name="us.dot.its.jpo.ode" level="DEBUG" />
 	<root level="WARN">
-		<appender-ref ref="DEFAULT" />
 		<appender-ref ref="STDOUT" />
 	</root>
 </configuration>


### PR DESCRIPTION
This PR includes a simple fix to the logback.xml file to remove the physical file logging, which is the root cause of issue #21.  When running an application with Docker it is best practice to log to the console and allow Docker to manage the log file itself. This PR accomplishes that.