### PR TITLE
Bug fix with Dockerfile not carrying deposit group name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=builder /home/target/jpo-aws-depositor-jar-with-dependencies.jar /ho
 CMD java -Dlogback.configurationFile=/home/logback.xml \
 	-jar /home/jpo-aws-depositor-jar-with-dependencies.jar \
 	--bootstrap-server $DOCKER_HOST_IP:9092 \
-	-g group1 \
+	-g $DEPOSIT_GROUP \
 	-t $DEPOSIT_TOPIC \
 	-b $DEPOSIT_BUCKET_NAME \
 	-k $DEPOSIT_KEY_NAME \


### PR DESCRIPTION
This PR is to address Issue #26. The only update is to the Dockerfile to bring the group name specified by the environment into the container itself rather than the hard-coded "group1" value. This is currently causing issues when spinning up multiple S3 depositors as each one has the "group1" grouping which confuses the Kafka broker. 