### PR TITLE
Updating Base Image & Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY ./src ./src
 
 RUN mvn clean package assembly:single
 
-FROM openjdk:8u171-jre-alpine
+FROM eclipse-temurin:11-jre-alpine
 
 COPY --from=builder /home/src/main/resources/logback.xml /home
 COPY --from=builder /home/target/jpo-aws-depositor-jar-with-dependencies.jar /home

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>usdot.jpo.ode</groupId>
   <artifactId>jpo-aws-depositor</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <packaging>jar</packaging>
   <name>JPO AWS Depositor</name>
   <properties>


### PR DESCRIPTION
The base image has been updated to eclipse-temurin:11-jre-alpine rather than the deprecated openjdk:8-jre-alpine image and the version in the pom.xml has been changed to 1.1.0 to match the version being used for the release.