### PR TITLE
Updated `Release_notes.md` for 2025 Q1 release

### DIFF
--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,6 +1,18 @@
 Jpo-s3-deposit Release Notes
 ----------------------------
 
+Version 1.7.0, released January 2025
+----------------------------------------
+### **Summary**
+The jpo-s3-deposit 1.7.0 release updates GitHub Actions workflows with the latest versions of third-party actions from external repositories to eliminate Node.js and other deprecation warnings.
+
+Enhancements in this release:
+- USDOT PR 67: Update GitHub Actions Third-Party Action Versions
+
+Known Issues:
+- No known issues at this time.
+
+
 Version 1.6.0, released September 2024
 ----------------------------------------
 ### **Summary**

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -7,7 +7,7 @@ Version 1.7.0, released January 2025
 The jpo-s3-deposit 1.7.0 release updates GitHub Actions workflows with the latest versions of third-party actions from external repositories to eliminate Node.js and other deprecation warnings.
 
 Enhancements in this release:
-- USDOT PR 67: Update GitHub Actions Third-Party Action Versions
+- [USDOT PR 67](https://github.com/usdot-jpo-ode/jpo-s3-deposit/pull/67): Update GitHub Actions Third-Party Action Versions
 
 Known Issues:
 - No known issues at this time.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>usdot.jpo.ode</groupId>
   <artifactId>jpo-aws-depositor</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.7.0</version>
   <packaging>jar</packaging>
   <name>JPO AWS Depositor</name>
   <properties>


### PR DESCRIPTION
## Problem  
A new version of `jpo-s3-deposit` (1.7.0) is set to be released this month. However, the release notes need to reflect the latest updates. Although no CDOT-specific changes were introduced this quarter, planned USDOT updates must be documented.

## Solution  
The release notes were updated to include details about upcoming USDOT changes. Since there were no CDOT changes this quarter, no additional modifications were necessary for the upstream merge.

## Testing  
The project packaging was successfully verified within the development container using the updated version (1.7.0). This ensures compatibility and readiness for the upstream merge.